### PR TITLE
feat: add tsvector and websearch support for query search

### DIFF
--- a/api-service/postgresql/schemas/init_db.sql
+++ b/api-service/postgresql/schemas/init_db.sql
@@ -1,7 +1,5 @@
 CREATE SCHEMA IF NOT EXISTS helper_schema;
 
-CREATE EXTENSION IF NOT EXISTS pg_trgm;
-
 DO $$
 BEGIN
 IF NOT EXISTS (select 1 from pg_type where typname = 'package_metadata' AND typnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'helper_schema')) then

--- a/api-service/postgresql/schemas/init_db.sql
+++ b/api-service/postgresql/schemas/init_db.sql
@@ -83,7 +83,8 @@ CREATE INDEX IF NOT EXISTS idx_packages_name ON packages(pkg_name);
 CREATE INDEX IF NOT EXISTS idx_packages_filename ON packages(pkg_filename);
 CREATE INDEX IF NOT EXISTS idx_packages_arch ON packages(pkg_arch);
 
-CREATE INDEX IF NOT EXISTS idx_packages_search ON packages USING gin (pkg_name gin_trgm_ops, pkg_desc gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_packages_search_vector ON packages USING gin ((to_tsvector('english', pkg_name) ||
+                                                                              to_tsvector('english', coalesce(pkg_desc, ''))));
 CREATE INDEX IF NOT EXISTS idx_packages_depends ON packages USING gin (pkg_depends);
 CREATE INDEX IF NOT EXISTS idx_packages_provides ON packages USING gin (pkg_provides);
 CREATE INDEX IF NOT EXISTS idx_packages_files ON packages USING gin (pkg_files);
@@ -258,57 +259,43 @@ END;
 $$
 LANGUAGE plpgsql STABLE;
 
-CREATE OR REPLACE FUNCTION helper_schema.search_packages_with_filters(_query text = null, _repo_filter text[] = null, _arch_filter text[] = null)
-        RETURNS SETOF helper_schema.brief_package
-        AS $$
-BEGIN
-        RETURN QUERY
-        SELECT *
-        FROM helper_schema.get_brief_packages_with_filters(_repo_filter, _arch_filter) AS p
-        WHERE
-            _query IS NULL OR
-            (p.pkg_name ILIKE '%' || _query || '%' OR
-            p.pkg_desc ILIKE '%' || _query || '%');
-END;
+CREATE OR REPLACE FUNCTION helper_schema.get_page_search_packages_with_offset(
+    _limit INTEGER = 100,
+    _offset INTEGER = 0,
+    _query TEXT = NULL,
+    _repo_filter TEXT[] = NULL,
+    _arch_filter TEXT[] = NULL
+) RETURNS helper_schema.brief_package_page_result AS
 $$
-LANGUAGE plpgsql STABLE;
-
-CREATE OR REPLACE FUNCTION helper_schema.search_offset_packages_with_filters(_limit integer = 100, _offset integer = 0, _query text = null, _repo_filter text[] = null, _arch_filter text[] = null)
-        RETURNS SETOF helper_schema.brief_package
-        AS $$
-BEGIN
-        RETURN QUERY
-        SELECT *
-        FROM helper_schema.search_packages_with_filters(_query, _repo_filter, _arch_filter) AS p
-        LIMIT _limit OFFSET _offset;
-END;
-$$
-LANGUAGE plpgsql STABLE;
-
-CREATE OR REPLACE FUNCTION helper_schema.get_page_search_packages_with_offset(_limit integer = 100, _offset integer = 0, _query text = null, _repo_filter text[] = null, _arch_filter text[] = null)
-        RETURNS helper_schema.brief_package_page_result
-        AS $$
 DECLARE
-        _result helper_schema.brief_package_page_result;
+    _result helper_schema.brief_package_page_result;
 BEGIN
-        SELECT COUNT(*) INTO _result.total_packages FROM helper_schema.search_packages_with_filters(_query, _repo_filter, _arch_filter);
+    WITH query_params AS ( SELECT websearch_to_tsquery('english', nullif(_query, '')) AS tsq ),
+         filtered_packages AS ( SELECT p.pkg_name,
+                                       p.repo_name,
+                                       p.pkg_arch,
+                                       p.pkg_version,
+                                       p.pkg_desc,
+                                       extract(EPOCH FROM p.pkg_builddate)::INTEGER AS pkg_builddate,
+                                       count(*) OVER ()                             AS total_count
+                                FROM packages p
+                                         CROSS JOIN query_params q
+                                WHERE (p.repo_name = ANY (_repo_filter) OR array_length(_repo_filter, 1) IS NULL)
+                                  AND (p.pkg_arch = ANY (_arch_filter) OR array_length(_arch_filter, 1) IS NULL)
+                                  AND (q.tsq IS NULL OR (to_tsvector('english', p.pkg_name) ||
+                                                         to_tsvector('english', coalesce(p.pkg_desc, ''))) @@ q.tsq)
+                                ORDER BY p.pkg_builddate DESC
+                                LIMIT _limit OFFSET _offset )
+    SELECT coalesce(( SELECT total_count FROM filtered_packages LIMIT 1 ), 0),
+           coalesce(
+                   array_agg(ROW(fp.pkg_name, fp.repo_name, fp.pkg_arch, fp.pkg_version, fp.pkg_desc, fp.pkg_builddate)::helper_schema.BRIEF_PACKAGE),
+                   ARRAY[]::helper_schema.BRIEF_PACKAGE[])
+    INTO _result.total_packages, _result.packages
+    FROM filtered_packages fp;
 
-        WITH paginated_data AS (
-            SELECT *
-            FROM helper_schema.search_offset_packages_with_filters(_limit, _offset, _query, _repo_filter, _arch_filter)
-        )
-        SELECT
-            COALESCE(
-                array_agg(
-                    ROW(pd.*)::helper_schema.brief_package
-                ),
-            ARRAY[]::helper_schema.brief_package[]) INTO _result.packages
-        FROM paginated_data pd;
-
-        RETURN _result;
+    RETURN _result;
 END;
-$$
-LANGUAGE plpgsql STABLE;
+$$ LANGUAGE plpgsql STABLE;
 
 CREATE OR REPLACE FUNCTION helper_schema.get_top_pkg_names(_limit integer = 10, _query text = null)
         RETURNS SETOF TEXT


### PR DESCRIPTION
This seems promising. But I couldn't start the service due to errors to test properly.

Also, the procedures are so dried up and use one another that I couldn't figure out a better way to put search_vector and order by ranking.
It's possible that ranking is not needed, need to check if the results make sense in dashboard.

I ran a "java" query and it produced less results, so that is something to check out. But since procedure gives back json, I couldn't verify easily.

```txt
Original:
Function Scan on get_page_search_packages_with_offset  (cost=0.25..0.26 rows=1 width=36) (actual time=1.756..1.756 rows=1.00 loops=1)
  Buffers: shared hit=294
Planning Time: 0.026 ms
Execution Time: 1.768 ms

New:
Function Scan on get_page_search_packages_with_offset_new  (cost=0.25..0.26 rows=1 width=36) (actual time=0.661..0.661 rows=1.00 loops=1)
  Buffers: shared hit=155
Planning Time: 0.022 ms
Execution Time: 0.671 ms
```

This is my testing queries:
<details>

<summary>Queries</summary>


```sql
ALTER TABLE packages
    ADD COLUMN search_vector TSVECTOR GENERATED ALWAYS AS (setweight(to_tsvector('english', pkg_name), 'A') ||
                                                           to_tsvector('english', coalesce(pkg_desc, '')) ) STORED;

CREATE INDEX idx_packages_search_vector ON packages USING gin (search_vector);

CREATE FUNCTION get_page_search_packages_with_offset_new(_limit integer DEFAULT 100, _offset integer DEFAULT 0, _query text DEFAULT NULL::text, _repo_filter text[] DEFAULT NULL::text[], _arch_filter text[] DEFAULT NULL::text[]) RETURNS helper_schema.brief_package_page_result
    STABLE
    LANGUAGE plpgsql AS
$$
DECLARE
    _result helper_schema.BRIEF_PACKAGE_PAGE_RESULT;
BEGIN
    WITH search_context AS ( SELECT websearch_to_tsquery('english', _query) AS query_obj,
                                    (_query IS NOT NULL AND _query != '')   AS is_active_search ),
         search_results AS ( SELECT count(*) OVER () AS total_count,
                                    -- get_brief_packages
                                    p.pkg_name,
                                    p.repo_name,
                                    p.pkg_arch,
                                    p.pkg_version,
                                    p.pkg_desc,
                                    p.pkg_builddate, -- let's get epoch later
                                    p.search_vector,
                                    CASE WHEN ctx.is_active_search THEN ts_rank(p.search_vector, ctx.query_obj)
                                         ELSE 0 END  AS rank,
                                    ctx.is_active_search
                             FROM packages p
                                      CROSS JOIN search_context ctx
                             WHERE
                                -- get_brief_packages_with_filters
                                 (_repo_filter IS NULL OR _repo_filter = '{}' OR p.repo_name = ANY (_repo_filter)) AND
                                 (_arch_filter IS NULL OR _arch_filter = '{}' OR p.pkg_arch = ANY (_arch_filter)) AND
                                 NOT ctx.is_active_search
                                OR p.search_vector @@ ctx.query_obj ),
         paginated_rows AS ( SELECT total_count,
                                    -- get_brief_packages
                                    pkg_name,
                                    repo_name,
                                    pkg_arch,
                                    pkg_version,
                                    pkg_desc,
                                    extract(EPOCH FROM pkg_builddate)::INTEGER AS pkg_builddate_epoch
                             FROM search_results
                             -- search_offset_packages_with_filters
                             ORDER BY CASE WHEN is_active_search THEN rank END DESC NULLS LAST, pkg_builddate DESC
                             LIMIT _limit OFFSET _offset )
    SELECT coalesce(( SELECT total_count FROM paginated_rows LIMIT 1 ), 0),
           coalesce(
                   array_agg(ROW (pkg_name, repo_name, pkg_arch, pkg_version, pkg_desc, pkg_builddate_epoch)::helper_schema.BRIEF_PACKAGE),
                   ARRAY []::helper_schema.BRIEF_PACKAGE[])
    INTO _result.total_packages, _result.packages
    FROM paginated_rows;

    RETURN _result;
END;
$$;
```

</details>
